### PR TITLE
Add a docker-compose file to make the building and running steps a little easier

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  rollout-js:
+    build: ./frontend-spring-boot-react-crud-full-stack-with-maven/.
+    ports:
+      - "3000:3000"
+  rollout-java:
+    build: ./backend-spring-boot-react-crud-full-stack-with-maven/.
+    ports:
+      - "8080:8080"


### PR DESCRIPTION

Now, instead of running..

```
docker build -t rollout-js .
docker build -t rollout-java .
docker run -d -p 3000:3000 rollout-js
docker run -d -p 8080:8080 rollout-java
```

You can now just run...
```
docker-compose build
docker-compose up .
```